### PR TITLE
docs(README): install @iconify/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Install
 npm i -D vite-plugin-icons
 ```
 
+And install `@iconify/json` as a dev dependency
+
+```bash
+npm i -D @iconify/json
+```
+
 Add it to `vite.config.js`
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Access thousands of icons as Vue components in Vite
 
 > ℹ️ **Vite 2 is supported from `v0.2.x`, Vite 1's support is discontinued.**
 
-Install plugin and peer `@iconify/json`dependency
+Install the plugin and peer dependency `@iconify/json`
 
 ```bash
 npm i -D vite-plugin-icons @iconify/json

--- a/README.md
+++ b/README.md
@@ -9,16 +9,10 @@ Access thousands of icons as Vue components in Vite
 
 > ℹ️ **Vite 2 is supported from `v0.2.x`, Vite 1's support is discontinued.**
 
-Install
+Install plugin and peer `@iconify/json`dependency
 
 ```bash
-npm i -D vite-plugin-icons
-```
-
-And install `@iconify/json` as a dev dependency
-
-```bash
-npm i -D @iconify/json
+npm i -D vite-plugin-icons @iconify/json
 ```
 
 Add it to `vite.config.js`


### PR DESCRIPTION
Added instruction to install peer dependency @iconify/json as a dev dependency to avoid this error https://github.com/antfu/vite-plugin-icons/issues/2